### PR TITLE
Add bounds support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,3 @@ This is, as everything else, a work in progress. Current known limitations are:
  * No support for UTFGrid interaction. Mostly because Leaflet does not currently support UTFGrid.
  * Only the first tile URL specified is used. The method for specifying this in the TileJSON 
    specification and in Leaflet differs in ways that makes it hard to implement in the general case.
- * Bounds are not used.

--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@
         },
         tiles: function(context, tileUrls) {
             context.tileUrls = tileUrls;
+        },
+        bounds: function(context, bounds) {
+            context.bounds = new L.LatLngBounds([[bounds[1], bounds[0]], [bounds[3], bounds[2]]]);
         }
     };
 


### PR DESCRIPTION
It appears Leaflet always had bounds support on TileLayer, but [it wasn't documented until recently](https://github.com/Leaflet/Leaflet/commit/f2ab783dbf765f91fd865ea0b4f7d103974f8368). I just noticed it and decided to quickly add support, based on [MapBox.js](https://github.com/mapbox/mapbox.js/blob/mb-pages/src/util.js#L32)
